### PR TITLE
Feature/execute completion block

### DIFF
--- a/dispatcher/src/main/kotlin/com/robotpajamas/dispatcher/Dispatchable.kt
+++ b/dispatcher/src/main/kotlin/com/robotpajamas/dispatcher/Dispatchable.kt
@@ -9,8 +9,7 @@ interface Dispatchable : Runnable, Cancellable, Completable, Executable, Timeout
 
     override fun execute() {
         execution.invoke { result ->
-            // Early return if failed, else nothing
-            result.failure { complete(result) }
+            complete(result)
         }
     }
 }

--- a/dispatcher/src/main/kotlin/com/robotpajamas/dispatcher/Result.kt
+++ b/dispatcher/src/main/kotlin/com/robotpajamas/dispatcher/Result.kt
@@ -21,13 +21,13 @@ sealed class Result<Value> {
     val isFailure: Boolean
         get() = !isSuccess
 
-    fun success(call: (Value) -> Unit) {
+    fun onSuccess(call: (Value) -> Unit) {
         if (this is Result.Success) {
             call(value)
         }
     }
 
-    fun failure(call: (Exception) -> Unit) {
+    fun onFailure(call: (Exception) -> Unit) {
         if (this is Result.Failure) {
             call(error)
         }


### PR DESCRIPTION
This PR addresses 2 things:

- Changes the execution block to invoke the completion block regardless of the result. Previously this only happened if the result was a failure

- Changes the Result API to clearly convey its functions' callback intent. success -> onSuccess; failure -> onFailure